### PR TITLE
Fix mobile documentation banner

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,7 +70,7 @@ html_theme = 'furo'
 html_logo = "_static/logo.png"
 html_favicon = "_static/logo.png"
 html_theme_options = {
-    "announcement": "Splam: a deep-learning-based splice site predictor that improves spliced alignments",
+    "announcement": "Splam: deep-learning splice-site prediction",
     "sidebar_hide_name": True,
     "source_repository": "https://github.com/Kuanhao-Chao/splam/",
     "source_branch": "main",


### PR DESCRIPTION
Shortens the Furo announcement so the full project descriptor fits at 390 px. Validated with Sphinx 9.1 strict mode, local-reference checks, and headless Chrome at mobile and desktop widths.